### PR TITLE
Move Axelor data to INI file

### DIFF
--- a/invconv/.gitignore
+++ b/invconv/.gitignore
@@ -1,4 +1,7 @@
 *.csv
+*.ini
+__pycache__
 *.xlsx
+!demo.ini
 !test/expected.csv
 !test/test.xlsx

--- a/invconv/demo.ini
+++ b/invconv/demo.ini
@@ -1,0 +1,123 @@
+[INFO]
+INVCONV_FORMAT = 1
+INI_VER = 1
+
+[CONSTANTS]
+AXELOR_PRODUCT_CATEGORIES = Package
+AXELOR_PRODUCT_FAMILIES = Equipment
+AXELOR_PRODUCT_TYPES = Product
+AXELOR_UNITS = Unit
+MAX_UNIT_SHORTHAND = 3
+
+[AXELOR_PRODUCT_CATEGORIES]
+Accomodation = 16
+Case = 7
+Hard Disk = 5
+Hosting = 1
+Maintenance = 2
+Meal = 15
+Memory = 8
+Motherboard = 9
+Non-perishable = 10
+Package = 18
+Perishable = 11
+Printer = 4
+Processor = 6
+Project based = 13
+Screen = 17
+Server = 3
+Time based = 12
+Transport = 14
+
+[AXELOR_PRODUCT_CATEGORIES_ABREV]
+Accomodation = ACCO
+Case = CASE
+Hard Disk = HDD
+Hosting = HOST
+Maintenance = MAIN
+Meal = MEAL
+Memory = MEM
+Motherboard = MOB
+Non-perishable = NPER
+Package = PACK
+Perishable = PER
+Print = PTR
+Processor = PROC
+Project based = PROB
+Screen = SCR
+Server = SER
+Time based = TIMB
+Transport = TRAN
+
+[AXELOR_PRODUCT_FAMILIES]
+Components = 3
+Consumables = 4
+Equipment = 2
+Expenses = 6
+Services = 5
+Subscription = 1
+
+[AXELOR_PRODUCT_FAMILIES_ABREV]
+Components = COMP
+Consumables = CONS
+Equipment = EQPT
+Expenses = TEXP
+Services = SERV
+Subscription = HSGT
+
+[AXELOR_PRODUCT_TYPES]
+product = NONE
+service = NONE
+
+[AXELOR_UNITS]
+Box of 1000 Pces = 10
+Box of 100 Pces = 8
+Box of 12 Pces = 5
+Box of 2 Pces = 3
+Box of 500 Pces = 9
+Box of 50 Pces = 7
+Box of 6 Pces = 4
+Centigrams = 20
+Centimeter = 29
+Day = 14
+Decagrams = 23
+Decameter = 32
+Decigrams = 21
+Grams = 22
+Half-Day = 13
+Hectograms = 24
+Hectometer = 33
+Hour = 12
+Kilograms = 25
+Kilometer = 34
+Meter = 31
+Miles = 35
+Milligrams = 19
+Millimeter = 28
+Minute = 11
+Month = 16
+Percent = 18
+Piece = 2
+Quintal = 26
+Ton = 27
+Unit = 1
+Week = 15
+Year = 17
+
+[AXELOR_UNITS_ABREV]
+Centigrams = cg
+Centimeter = cm
+Decagrams = dag
+Decameter = dam
+Grams = g
+Hectograms = hg
+Hectometer = hm
+Hour = hr
+Kilograms = kg
+Kilometer = km
+Minute = min
+Percent = %
+Piece = pce
+Ton = t
+Unit = u
+Year = a

--- a/invconv/modules/__init__.py
+++ b/invconv/modules/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2021 Richard Johnston <techpowerawaits@outlook.com>
+# SPDX-license-identifier: 0BSD
+pass

--- a/invconv/modules/invconv_ini.py
+++ b/invconv/modules/invconv_ini.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Richard Johnston <techpowerawaits@outlook.com>
+# SPDX-license-identifier: 0BSD
+import configparser
+
+data_parser = configparser.RawConfigParser(
+    allow_no_value=False,
+    delimiters=["="],
+    comment_prefixes=["#"],
+    strict=True,
+    empty_lines_in_values=True,
+    default_section=None,
+    interpolation=None,
+)
+data_parser.optionxform = lambda option: option


### PR DESCRIPTION
The Axelor data originally included with the ax-invconv script was based
off of an examination of Axelor Demo Data. Since the production version
doesn't contain the same categories and other data, and, as well, custom
data can be added to Axelor, all data has been moved to a seperate file.
This should allow for more flexibility in using the script.