### PR TITLE
get: Readd chown support

### DIFF
--- a/get/ax-get.py
+++ b/get/ax-get.py
@@ -26,8 +26,11 @@ DEFAULT_BRANDING_FILE = "branding_logo.png"
 PAUSE_SECONDS = 3
 
 ver_path = os.path.join(os.path.pardir, "VERSION")
-with open(ver_path, "r") as version_file:
-    ver_str = version_file.readline()
+try:
+    with open(ver_path, "r") as version_file:
+        __version__ = version_file.readline()
+except FileNotFoundError:
+    __version__ = "Unknown"
 
 # Source code wise, Axelor Open Suite depends on Axelor Open Webapp.
 # Each url should provide binary WAR files with priority given to
@@ -49,7 +52,7 @@ default_war_basename = "axelor-erp-v"
 parser = argparse.ArgumentParser(
     description="Grabs a copy of Axelor", epilog="Licensed under the 0BSD."
 )
-parser.add_argument("-v", "--version", action="version", version=ver_str)
+parser.add_argument("-v", "--version", action="version", version=__version__)
 parser.add_argument("-s", "--src", action="store_true")
 parser.add_argument(
     "-b", "--brand_file", default=DEFAULT_BRANDING_FILE, help="Path to logo"

--- a/get/posix_compat.py
+++ b/get/posix_compat.py
@@ -1,0 +1,69 @@
+# Copyright 2021 Richard Johnston <techpowerawaits@outlook.com>
+# SPDX-license-identifier: 0BSD
+
+import collections
+import copy
+import getpass
+import os
+import sys
+
+user_tuple = collections.namedtuple("user_tuple", ("name", "uid", "gid"))
+
+if os.name == "posix":
+    import pwd
+
+
+def make_root():
+    if os.name == "posix":
+        if not getpass.getuser() == "root":
+            # Need to perform a deep copy, as it
+            # wouldn't be good to modify the original.
+            script_arg_list = copy.deepcopy(sys.argv)
+            # Try to get the absolute path to the
+            # Python script so if one of the root-granting
+            # programs error out, it might provide a more
+            # useful error message.
+            script_arg_list[0] = os.path.abspath(script_arg_list[0])
+            # Make sure all arguments are converted to str.
+            for index, arg in enumerate(script_arg_list):
+                if not isinstance(arg, str):
+                    script_arg_list[index] = str(arg)
+            # Now the entire list can become a string that
+            # can easily be used.
+            script_args = " ".join(script_arg_list)
+            if (
+                os.system(f"pkexec {script_args}") == 0
+                or os.system(f"sudo {script_args}") == 0
+                or os.system(f"su root '{script_args}'") == 0
+            ):
+                # Need to exit out of script if the script
+                # has already run as root once.
+                sys.exit()
+        # Must be root.
+        return True
+    # Default to False for non-POSIX platforms.
+    return False
+
+
+def get_tomcat_info():
+    tomcat_name = "tomcat"
+    tomcat_uid = -1
+    tomcat_gid = -1
+    if os.name == "posix":
+        try:
+            tomcat_info = pwd.getpwnam("tomcat")
+            tomcat_uid = tomcat_info[2]
+            tomcat_gid = tomcat_info[3]
+        except KeyError:
+            tomcat_name = None
+    return user_tuple(tomcat_name, tomcat_uid, tomcat_gid)
+
+
+# A recursive chown function.
+def chown_r(path, uid, gid):
+    for dirpath, dirnames, filenames in os.walk(path, followlinks=False):
+        # Prospector complains that dirnames isn't used, otherwise.
+        del dirnames
+        os.chown(dirpath, uid, gid)
+        for filename in filenames:
+            os.chown(os.path.join(dirpath, filename), uid, gid)

--- a/get/tmp_name.py
+++ b/get/tmp_name.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Richard Johnston <techpowerawaits@outlook.com>
+# SPDX-license-identifier: 0BSD
+
+"""Uses the tempfile module to create random file names."""
+
+import collections
+import os
+import tempfile
+
+# Since many values are going to be appended,
+# use deque instead of a list.
+tmp_name_tracker = collections.deque()
+
+
+def init(target_dir=os.path.curdir):
+    """Ensures that no name is going to conflict with one inside the given directory."""
+    global tmp_name_tracker
+    tmp_name_tracker.extend(os.listdir(target_dir))
+    if not tmp_name_tracker:
+        # At least one string should be in
+        # tmp_name_tracker, so it has to be
+        # one that can never exist on the file
+        # system.
+        tmp_name_tracker.append("$TEMP$")
+
+
+def get():
+    """Returns a tmp_name."""
+    global tmp_name_tracker
+    # Needs something that is in tmp_name_tracker
+    # so that the while loop will be entered at least
+    # once.
+    tmp_name = tmp_name_tracker[0]
+    while tmp_name in tmp_name_tracker:
+        with tempfile.NamedTemporaryFile() as tmp_fptr:
+            tmp_name = tmp_fptr.name
+    tmp_name_tracker.append(tmp_name)
+    return tmp_name

--- a/invconv/ax-invconv.py
+++ b/invconv/ax-invconv.py
@@ -18,8 +18,11 @@ from modules import invconv_logic
 from modules import msg_handler
 
 ver_path = os.path.join(os.path.pardir, "VERSION")
-with open(ver_path, "r") as version_file:
-    ver_str = version_file.readline()
+try:
+    with open(ver_path, "r") as version_file:
+        __version__ = version_file.readline()
+except FileNotFoundError:
+    __version__ = "Unknown"
 
 parser = argparse.ArgumentParser(
     description="Converts inventory lists to a Axelor-compatible CSV format",
@@ -41,7 +44,7 @@ parser.add_argument(
 parser.add_argument(
     "-h", "--help", action="help", help="show this help message and exit"
 )
-parser.add_argument("-v", "--version", action="version", version=ver_str)
+parser.add_argument("-v", "--version", action="version", version=__version__)
 
 parser.add_argument(
     "-t",


### PR DESCRIPTION
When 'ax-get.sh' was removed, some functionality was lost. Originally, it chowned the folder it extracted so that it was owned by the tomcat user and group. This functionality has been restored and new relevant features have been added.