### PR TITLE
Pin dependencies

### DIFF
--- a/get/requirements.txt
+++ b/get/requirements.txt
@@ -1,1 +1,4 @@
 requests~=2.26.0
+chardet~=4.0.0
+idna~=3.2
+urllib3~=1.26.5

--- a/invconv/requirements.txt
+++ b/invconv/requirements.txt
@@ -1,8 +1,9 @@
-# Requirements for ax-invconv.py
-openpyxl~=3.0.7
-progress ~= 1.5
 # Most Linux distros providing openpyxl
 # add a dependency on jdcal. Seems like it
 # was required for a previous version, but
 # upstream no longer mentions it in their
 # requirements file.
+openpyxl~=3.0.7
+et-xmlfile~=1.1.0
+
+progress ~= 1.5


### PR DESCRIPTION
So that things are less likely to break when a package gets updated.