### PR TITLE
invconv: Allow specifying output

### DIFF
--- a/invconv/common.py
+++ b/invconv/common.py
@@ -27,6 +27,14 @@ arg_tuple = collections.namedtuple("arg_tuple", ("short", "long", "help"))
 # When enabled, provides extra debugging information.
 is_debug = False
 
+# Axelor CSV type is used as filename if only directory has been provided
+# in arguments to the script.
+axelor_csv_type = ""
+
+# Stores the output_file, which is either a string to a file or
+# a file stream.
+output_file_path = ""
+
 # Supported data file version number.
 # Must be exact match.
 SUPPORTED_FORMAT_VER = 4
@@ -38,6 +46,7 @@ def init(fptr):
 
     global arg_dict
     global axelor_csv_columns
+    global axelor_csv_type
     global constants
     global fallback
     global meta_table

--- a/invconv/logic.py
+++ b/invconv/logic.py
@@ -3,7 +3,6 @@
 
 import csv
 import string
-import sys
 
 from loguru import logger
 
@@ -300,8 +299,13 @@ def main(val):
 
 
 def commit_headers():
-    csv_out = csv.writer(sys.stdout, dialect="excel")
-    csv_out.writerow(common.axelor_csv_columns)
+    if isinstance(common.output_file_path, str):
+        with open(common.output_file_path, "a", newline="") as fptr:
+            csv_out = csv.writer(fptr, dialect="excel")
+            csv_out.writerow(common.axelor_csv_columns)
+    else:
+        csv_out = csv.writer(common.output_file_path, dialect="excel")
+        csv_out.writerow(common.axelor_csv_columns)
 
 
 import_id_incr = 0
@@ -325,6 +329,11 @@ def commit_row():
     for ax_column in common.axelor_csv_columns:
         row_list.append(csv_row[ax_column])
 
-    csv_out = csv.writer(sys.stdout, dialect="excel")
-    csv_out.writerow(row_list)
+    if isinstance(common.output_file_path, str):
+        with open(common.output_file_path, "a", newline="") as fptr:
+            csv_out = csv.writer(fptr, dialect="excel")
+            csv_out.writerow(row_list)
+    else:
+        csv_out = csv.writer(common.output_file_path, dialect="excel")
+        csv_out.writerow(row_list)
     csv_row.clear()


### PR DESCRIPTION
An output file (or directory) is now required for the script to run. In
debug mode, if no output file/dir is specified, it will still default to
sys.stderr.